### PR TITLE
Upgraded broken dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "require-nocache": "^1.0.0",
     "solc": "0.4.8",
     "temp": "^0.8.3",
-    "truffle-blockchain-utils": "0.0.1",
-    "web3": "^0.18.2"
+    "truffle-blockchain-utils": "~0.0.1",
+    "web3": "^0.19.1"
   },
   "dependencies": {
     "async": "^1.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truffle-artifactor",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "A contract packager for Ethereum and Javascript",
   "author": "Tim Coulter",
   "main": "./index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truffle-artifactor",
-  "version": "2.1.5",
+  "version": "2.1.4",
   "description": "A contract packager for Ethereum and Javascript",
   "author": "Tim Coulter",
   "main": "./index.js",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "require-nocache": "^1.0.0",
     "solc": "0.4.8",
     "temp": "^0.8.3",
-    "truffle-blockchain-utils": "~0.0.1",
+    "truffle-blockchain-utils": "0.0.1",
     "web3": "^0.19.1"
   },
   "dependencies": {


### PR DESCRIPTION
Fixes https://github.com/trufflesuite/truffle-artifactor/issues/52

Upgraded [web3](https://github.com/ethereum/web3.js) to 0.19.1 due to https://github.com/ethereum/web3.js/issues/904
Upgraded [truffle-blockchain-utils](https://github.com/trufflesuite/truffle-blockchain-utils) to ~0.0.1 due to https://github.com/trufflesuite/truffle-blockchain-utils/issues/3

Depends on hotfixes for:
- https://github.com/ethereumjs/testrpc/issues/332
- https://github.com/trufflesuite/truffle-blockchain-utils/issues/3
- https://github.com/trufflesuite/truffle-contract/issues/31