### PR TITLE
Use _.assign instead of _.merge

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var fs = require("fs-extra");
 var path = require("path");
 var async = require("async");
 var _ = require("lodash");
+var debug = require("debug")("artifactor");
 
 function Artifactor(destination) {
   this.destination = destination;
@@ -44,7 +45,14 @@ Artifactor.prototype.save = function(object) {
 
         // normalize existing and merge into final
         finalObject = Schema.normalize(existingObjDirty);
-        _.merge(finalObject, object);
+
+        // merge networks
+        var finalNetworks = {};
+        _.merge(finalNetworks, finalObject.networks, object.networks);
+
+        // update existing with new
+        _.assign(finalObject, object);
+        finalObject.networks = finalNetworks;
       }
 
       // update timestamp

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "async": "^1.5.2",
+    "debug": "^3.1.0",
     "fs-extra": "^1.0.0",
     "lodash": "^4.11.2",
     "truffle-contract": "^3.0.0",

--- a/test/contracts.js
+++ b/test/contracts.js
@@ -7,7 +7,7 @@ var path = require("path");
 var solc = require("solc");
 var fs = require("fs");
 var requireNoCache = require("require-nocache")(module);
-var TestRPC = require("ethereumjs-testrpc");
+var TestRPC = require("ganache-cli");
 var Web3 = require("web3");
 
 describe("artifactor + require", function() {


### PR DESCRIPTION
This should address most of the `invalid number of arguments to a Solidity function` problems.

Refs: https://github.com/trufflesuite/truffle/issues/596 https://github.com/trufflesuite/truffle/issues/698 https://github.com/trufflesuite/truffle/issues/706 
(although these may or may not be the same issue)

`_.merge()` has the property that it recursively merges objects. Since the ABI is an array, this merge is... dangerous.

- Specifically set to merge artifact `networks` property
- Simply assign for all other properties