### PR TITLE
Allow newer versions of solidity 0.4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "ganache-cli": "6.0.3",
     "mocha": "^2.3.4",
     "require-nocache": "^1.0.0",
-    "solc": "0.4.8",
+    "solc": "^0.4.8",
     "temp": "^0.8.3",
     "truffle-blockchain-utils": "^0.0.3",
     "web3": "^0.20.1"


### PR DESCRIPTION
I'm not sure this is even used at the moment, but it's locked to a really super old version of solc.

Truffle should not restrict solc to a specific version (0.4.8) because semantic versioning specifies that only non-breaking changes will be included in the 0.4.x series.

See also https://github.com/trufflesuite/truffle/pull/784