### PR TITLE
Make tests compatible with web3.1 checksum addresses

### DIFF
--- a/test/contracts.js
+++ b/test/contracts.js
@@ -151,7 +151,7 @@ describe("artifactor + require", function() {
       var log = result.logs[0];
 
       assert.equal("ExampleEvent", log.event);
-      assert.equal(accounts[0], log.args._from);
+      assert.equal(accounts[0], log.args._from.toLowerCase());
       assert.equal(8, log.args.num); // 8 is a magic number inside Example.sol
     }).then(done).catch(done);
   });


### PR DESCRIPTION
Web3 1.0 returns all addresses checksummed. This is a breaking change, but probably one we'd like to preserve rather than paper over for backward compatibility. 
